### PR TITLE
Refactor/teampage

### DIFF
--- a/icey/src/main/java/com/project/icey/app/controller/TeamController.java
+++ b/icey/src/main/java/com/project/icey/app/controller/TeamController.java
@@ -66,6 +66,7 @@ public class TeamController {
                                                       @PathVariable String invitationToken){
         User user = userDetails.getUser();
         teamService.joinTeamByInvitation(user, invitationToken);
+
         return ApiResponseTemplete.success(SuccessCode.JOIN_TEAM_SUCCESS, null);
     }
     //초대링크를 통한 초대장(팀 정보) 조회

--- a/icey/src/main/java/com/project/icey/app/controller/TeamController.java
+++ b/icey/src/main/java/com/project/icey/app/controller/TeamController.java
@@ -82,16 +82,8 @@ public class TeamController {
     //초대링크를 통한 초대장(팀 정보) 조회
     @GetMapping("/invitation/{invitationToken}")
     public ResponseEntity<?> getTeamInfoByInvitationToken(@PathVariable String invitationToken) {
-        try {
-            InvitationTeamInfoResponse response = teamService.getTeamInfoByInvitation(invitationToken);
-            return ResponseEntity.ok(response);
-        } catch (ResponseStatusException e) {
-            return ResponseEntity.status(e.getStatusCode())
-                    .body(new ErrorResponse(e.getReason()));
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(new ErrorResponse("서버 오류가 발생했습니다."));
-        }
+        InvitationTeamInfoResponse response = teamService.getTeamInfoByInvitation(invitationToken);
+        return ResponseEntity.ok(response);
     }
 
 

--- a/icey/src/main/java/com/project/icey/app/controller/TeamController.java
+++ b/icey/src/main/java/com/project/icey/app/controller/TeamController.java
@@ -9,6 +9,8 @@ import com.project.icey.app.repository.TeamRepository;
 import com.project.icey.app.repository.UserTeamRepository;
 import com.project.icey.app.service.TeamService;
 
+import com.project.icey.global.dto.ApiResponseTemplete;
+import com.project.icey.global.exception.SuccessCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -30,33 +32,32 @@ public class TeamController {
 
     // 팀 생성
     @PostMapping("")
-    public ResponseEntity<TeamResponse> createTeam(@AuthenticationPrincipal CustomUserDetails userDetails,
+    public ResponseEntity<?> createTeam(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                    @RequestBody CreateTeamRequest createTeamRequest) {
         User user = userDetails.getUser();
         TeamResponse response = teamService.createTeam(createTeamRequest, user);
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        return ApiResponseTemplete.success(SuccessCode.CREATE_TEAM_SUCCESS, response);
     }
 
     // 유저별 팀 목록 조회 + 여기서 user가 리더인지 아닌지 추가로 필요할 듯 -> 필요없어짐 + 현재 있는 팀이 무엇인지에
     @GetMapping("")
-    public ResponseEntity<List<TeamResponse>> getTeam(@AuthenticationPrincipal CustomUserDetails userDetails) {
+    public ResponseEntity<?>  getTeam(@AuthenticationPrincipal CustomUserDetails userDetails) {
         User user = userDetails.getUser();
         List<TeamResponse> teams = teamService.getTeamsByUser(user);
-        return ResponseEntity.ok(teams);
+        return ApiResponseTemplete.success(SuccessCode.GET_TEAM_LIST_SUCCESS, teams);
 
     }
 
     //팀별 초대링크 조회 - 에러처리음 후순위
     @GetMapping("/{teamId}/invitation")
-    public ResponseEntity<InvitationResponse> checkInvitation(@AuthenticationPrincipal CustomUserDetails userDetails,
+    public ResponseEntity<?> checkInvitation(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                               @PathVariable("teamId") Long teamId) {
 
         User user = userDetails.getUser();
-
         InvitationResponse response = teamService.getInvitation(user, teamId);
 
-        return ResponseEntity.ok(response);
+        return ApiResponseTemplete.success(SuccessCode.GET_INVITATION_SUCCESS, response);
     }
 
     //초대 링크 수락
@@ -64,40 +65,28 @@ public class TeamController {
     public ResponseEntity<?> joinTeam(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                       @PathVariable String invitationToken){
         User user = userDetails.getUser();
-        try {
-            UserTeamJoinResponse response = teamService.joinTeamByInvitation(user, invitationToken);
-            return ResponseEntity.status(HttpStatus.CREATED).body(response);
-
-        } catch (ResponseStatusException e) {
-            return ResponseEntity
-                    .status(e.getStatusCode())
-                    .body(new ErrorResponse(e.getReason()));
-        } catch (Exception e) {
-            //e.printStackTrace();
-            return ResponseEntity
-                    .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(new ErrorResponse("서버 오류가 발생했습니다."));
-        }
+        teamService.joinTeamByInvitation(user, invitationToken);
+        return ApiResponseTemplete.success(SuccessCode.JOIN_TEAM_SUCCESS, null);
     }
     //초대링크를 통한 초대장(팀 정보) 조회
     @GetMapping("/invitation/{invitationToken}")
     public ResponseEntity<?> getTeamInfoByInvitationToken(@PathVariable String invitationToken) {
         InvitationTeamInfoResponse response = teamService.getTeamInfoByInvitation(invitationToken);
-        return ResponseEntity.ok(response);
+        return ApiResponseTemplete.success(SuccessCode.GET_TEAM_INFO_BY_INVITATION_SUCCESS, response);
     }
 
 
-    // 팀별 상세 기본정보 조회
+    // 팀별 상세 정보 조회
     @GetMapping("/{teamId}")
-    public ResponseEntity<TeamDetailResponse> getTeamDetail(@AuthenticationPrincipal CustomUserDetails userDetails,
+    public  ResponseEntity<?> getTeamDetail(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                             @PathVariable Long teamId) {
         User user = userDetails.getUser();
         TeamDetailResponse response = teamService.getTeamDetail(teamId, user);
-        return ResponseEntity.ok(response);
+        return ApiResponseTemplete.success(SuccessCode.GET_TEAM_DETAIL_SUCCESS, response);
     }
 
     // 팀 폭파
-    @DeleteMapping("/{teamId}")
+    /*@DeleteMapping("/{teamId}")
     public ResponseEntity<String> DeleteTeam(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                    @PathVariable Long teamId){
         User user = userDetails.getUser();
@@ -132,6 +121,7 @@ public class TeamController {
 
         userteamRepository.delete(utm);
         return ResponseEntity.noContent().build();
-    }
+    }*/
+    //안녕 나의 코드들...
 
 }

--- a/icey/src/main/java/com/project/icey/app/domain/CandidateDate.java
+++ b/icey/src/main/java/com/project/icey/app/domain/CandidateDate.java
@@ -27,5 +27,6 @@ public class CandidateDate {
 
     //이제 실제 투표와 연결
     @OneToMany(mappedBy = "candidateDate", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
     private List<ScheduleTimeSlot> timeSlots = new ArrayList<>();
 }

--- a/icey/src/main/java/com/project/icey/app/domain/Letter.java
+++ b/icey/src/main/java/com/project/icey/app/domain/Letter.java
@@ -35,6 +35,7 @@ public class Letter {
     private LocalDateTime sentAt;
 
     @Column(nullable = false)
+    @Builder.Default
     private boolean isRead = false;
 
     @CreationTimestamp

--- a/icey/src/main/java/com/project/icey/app/domain/Schedule.java
+++ b/icey/src/main/java/com/project/icey/app/domain/Schedule.java
@@ -35,6 +35,7 @@ public class Schedule {
 
     //여러 후보들 받을거니까
     @OneToMany(mappedBy = "schedule", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
     private List<CandidateDate> candidateDates = new ArrayList<>();
 
     // 확정된 날짜

--- a/icey/src/main/java/com/project/icey/app/domain/ScheduleTimeSlot.java
+++ b/icey/src/main/java/com/project/icey/app/domain/ScheduleTimeSlot.java
@@ -22,6 +22,7 @@ public class ScheduleTimeSlot {
     private CandidateDate candidateDate;
 
     @OneToMany(mappedBy = "timeSlot", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
     private java.util.List<ScheduleVote> votes = new java.util.ArrayList<>();
 
 

--- a/icey/src/main/java/com/project/icey/app/domain/Team.java
+++ b/icey/src/main/java/com/project/icey/app/domain/Team.java
@@ -37,7 +37,7 @@ public class Team {
     private String invitation;
 
     @OneToMany(mappedBy = "team", cascade = CascadeType.ALL, orphanRemoval = true)
-        //@Builder.Default    //빌드 오류나서 우선 추가해보았습니다   -서현,,,,
+    @Builder.Default    //빌드 오류나서 우선 추가해보았습니다   -서현,,,, 넣는게 좋을 것 같아요!! 몰랐슴다.. -상희
     private List<UserTeamManager> members = new ArrayList<>();
 
     @PrePersist

--- a/icey/src/main/java/com/project/icey/app/domain/UserTeamManager.java
+++ b/icey/src/main/java/com/project/icey/app/domain/UserTeamManager.java
@@ -22,9 +22,6 @@ public class UserTeamManager {
     @ManyToOne
     private User user;
 
-    //nickname은 추후 card와 연결
-    private String nickname;
-
     @Enumerated(EnumType.STRING)  // enum을 문자열로 DB 저장
     private UserRole role;
 

--- a/icey/src/main/java/com/project/icey/app/dto/InvitationTeamInfoResponse.java
+++ b/icey/src/main/java/com/project/icey/app/dto/InvitationTeamInfoResponse.java
@@ -6,7 +6,6 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class InvitationTeamInfoResponse {
-    private final Long teamId;
     private final String teamName;
-    private final long memberCount;
+    private final String leaderName;
 }

--- a/icey/src/main/java/com/project/icey/app/dto/TeamDetailResponse.java
+++ b/icey/src/main/java/com/project/icey/app/dto/TeamDetailResponse.java
@@ -14,4 +14,6 @@ public class TeamDetailResponse {
     private String currentDate;
     private String dDay;
     private String role;
+    private boolean hasSchedule;
+    private String confirmedDate;
 }

--- a/icey/src/main/java/com/project/icey/app/dto/TeamDetailResponse.java
+++ b/icey/src/main/java/com/project/icey/app/dto/TeamDetailResponse.java
@@ -11,5 +11,7 @@ public class TeamDetailResponse {
     private Long teamId;
     private String teamName;
     private Integer memberCount;
+    private String currentDate;
     private String dDay;
+    private String role;
 }

--- a/icey/src/main/java/com/project/icey/app/dto/TeamResponse.java
+++ b/icey/src/main/java/com/project/icey/app/dto/TeamResponse.java
@@ -9,6 +9,5 @@ import lombok.Getter;
 public class TeamResponse {
     private Long id;
     private String teamName;
-    private String invitation;
     private String dDay;
 }

--- a/icey/src/main/java/com/project/icey/app/repository/CardRepository.java
+++ b/icey/src/main/java/com/project/icey/app/repository/CardRepository.java
@@ -1,6 +1,8 @@
 package com.project.icey.app.repository;
 
 import com.project.icey.app.domain.Card;
+import com.project.icey.app.domain.Team;
+import com.project.icey.app.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -21,6 +23,8 @@ public interface CardRepository extends JpaRepository<Card, Long> {
     List<Card> findByOriginId(Long originId);
     //이 템플릿을 쓰는 팀카드가 하나라도 있는지?
     boolean existsByOriginId(Long originId);
+
+    Optional<Card> findByUserAndTeam(User user, Team team);
 }
 
 //findByTeamId

--- a/icey/src/main/java/com/project/icey/app/service/TeamCleanupService.java
+++ b/icey/src/main/java/com/project/icey/app/service/TeamCleanupService.java
@@ -1,19 +1,24 @@
 package com.project.icey.app.service;
 
+import com.project.icey.app.domain.NotificationType;
 import com.project.icey.app.domain.Team;
+import com.project.icey.app.domain.UserTeamManager;
 import com.project.icey.app.repository.TeamRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class TeamCleanupService {
     private final TeamRepository teamRepository;
+    private final NotificationService notificationService;
 
     @Scheduled( cron = "0 0 0 * * *")//테스트 용으로 10초마다 삭제하도록(fixedDelay = 10000)
     @Transactional
@@ -31,6 +36,39 @@ public class TeamCleanupService {
             teamRepository.deleteAll(expiredTeams);
         } else {
             System.out.println("[TeamCleanup] 삭제할 만료 팀 없음 (현재 시간: " + now + ")");
+        }
+    }
+
+    //만료 3일전 1일전 알림 발송
+    @Transactional
+    @Scheduled(cron = "0 0 0 * * *") //(fixedDelay = 10000)
+    public void notifyTeamExpiration() {
+        LocalDate now = LocalDate.now();
+        List<Team> teams = teamRepository.findAll();
+
+        for (Team team : teams) {
+            long daysLeft = ChronoUnit.DAYS.between(now, team.getExpiration().toLocalDate());
+
+            if (daysLeft == 3 || daysLeft == 1) {
+                String message;
+                if (daysLeft == 3) {
+                    message = "[" + team.getTeamName() + "] 팀 페이지 삭제까지 3일 남았어요!";
+                } else {
+                    message = "[" + team.getTeamName() + "] 팀 페이지 삭제까지 하루 남았어요!";
+                }
+
+                // 팀 멤버들 가져오기
+                List<UserTeamManager> members = team.getMembers();
+
+                // 각 멤버에게 알림 전송
+                for (UserTeamManager member : members) {
+                    notificationService.sendNotification(
+                            member.getUser().getId(),
+                            NotificationType.TEAM_EXPIRATION,
+                            message
+                    );
+                }
+            }
         }
     }
 }

--- a/icey/src/main/java/com/project/icey/app/service/TeamService.java
+++ b/icey/src/main/java/com/project/icey/app/service/TeamService.java
@@ -51,7 +51,6 @@ public class TeamService {
         return new TeamResponse(
                 team.getTeamId(),
                 team.getTeamName(),
-                invitationLink,
                 dDay
         );
     }
@@ -71,7 +70,6 @@ public class TeamService {
                     return new TeamResponse(
                             team.getTeamId(),
                             team.getTeamName(),
-                            team.getInvitation(),
                             dDay
 
                     );

--- a/icey/src/main/java/com/project/icey/app/service/TeamService.java
+++ b/icey/src/main/java/com/project/icey/app/service/TeamService.java
@@ -180,10 +180,17 @@ public class TeamService {
                 .findFirst()
                 .orElseThrow(() ->  new IllegalArgumentException("팀에 리더가 존재하지 않습니다."));
         User leader = leaderUtm.getUser();
-        Card leaderCard = cardRepository.findByUserAndTeam(leader, team)
+        
+        //만약 팀장이 아직 명함을 안만들었다면.. ver1 아예 에러 뜨게 처리 안좋은것 같음
+        /*Card leaderCard = cardRepository.findByUserAndTeam(leader, team)
                 .orElseThrow(() -> new IllegalArgumentException("리더의 명함이 존재하지 않습니다."));
 
-        String leaderNickname = leaderCard.getNickname();
+        String leaderNickname = leaderCard.getNickname();*/
+        
+        //미등록은 닉네임 미등록 사용자로 처리하는거 어떤지 물어보기
+        String leaderNickname = cardRepository.findByUserAndTeam(leader, team)
+                .map(Card::getNickname)
+                .orElse("닉네임 미등록 사용자");
 
 
         return new InvitationTeamInfoResponse(

--- a/icey/src/main/java/com/project/icey/app/service/TeamService.java
+++ b/icey/src/main/java/com/project/icey/app/service/TeamService.java
@@ -6,6 +6,7 @@ import com.project.icey.app.repository.*;
 import com.project.icey.global.exception.ErrorCode;
 import com.project.icey.global.exception.model.CoreApiException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,6 +29,9 @@ public class TeamService {
     private final CardRepository cardRepository;
     private final ScheduleRepository scheduleRepository;
 
+    @Value("${app.base-url}")
+    private String baseUrl;
+
     public TeamResponse createTeam(CreateTeamRequest request, User creator){
         Team team = Team.builder() //
                 .teamName(request.getTeamName())
@@ -45,8 +49,6 @@ public class TeamService {
         userteamRepository.save(utm);
 
         //int memberCnt = userteamRepository.countByTeam(team);
-
-        String invitationLink = "http://localhost:8080/icey/invitation/"+team.getInvitation();
         long days = Duration.between(LocalDateTime.now(), team.getExpiration()).toDays();
         String dDay = "D-" + days;
 
@@ -84,7 +86,7 @@ public class TeamService {
         Team team = teamRepository.findById(teamId)
                 .orElseThrow(() -> new CoreApiException(ErrorCode.TEAM_NOT_FOUND));
 
-        String invitationLink = "http://localhost:8080/icey/invitation/"+team.getInvitation();
+        String invitationLink = baseUrl + "/invitation/"+team.getInvitation();
 
         return new InvitationResponse(
                 team.getTeamId(),

--- a/icey/src/main/java/com/project/icey/app/service/TeamService.java
+++ b/icey/src/main/java/com/project/icey/app/service/TeamService.java
@@ -15,6 +15,7 @@ import org.springframework.web.server.ResponseStatusException;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.UUID;
@@ -144,12 +145,21 @@ public class TeamService {
         long daysLeft = ChronoUnit.DAYS.between(LocalDate.now(), team.getExpiration().toLocalDate());
         String dDay ="D-" + daysLeft;
 
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MM.dd");
+        String currentDate = LocalDate.now().format(formatter);
+
+        UserTeamManager userTeamManager = userteamRepository.findByUserAndTeam(user, team)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.FORBIDDEN, "팀의 멤버가 아닙니다."));
+
+        UserRole role = userTeamManager.getRole();
+
         return new TeamDetailResponse(
                 team.getTeamId(),
                 team.getTeamName(),
                 memberCnt,
-                dDay
-
+                currentDate,
+                dDay,
+                role.name()
         );
 
     }

--- a/icey/src/main/java/com/project/icey/app/service/TeamService.java
+++ b/icey/src/main/java/com/project/icey/app/service/TeamService.java
@@ -3,6 +3,8 @@ package com.project.icey.app.service;
 import com.project.icey.app.domain.*;
 import com.project.icey.app.dto.*;
 import com.project.icey.app.repository.*;
+import com.project.icey.global.exception.ErrorCode;
+import com.project.icey.global.exception.model.CoreApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -80,7 +82,7 @@ public class TeamService {
 
     public InvitationResponse getInvitation(User user, Long teamId){
         Team team = teamRepository.findById(teamId)
-                .orElseThrow(() -> new IllegalArgumentException("Team을 찾지 못했습니다"));
+                .orElseThrow(() -> new CoreApiException(ErrorCode.TEAM_NOT_FOUND));
 
         String invitationLink = "http://localhost:8080/icey/invitation/"+team.getInvitation();
 

--- a/icey/src/main/java/com/project/icey/global/exception/SuccessCode.java
+++ b/icey/src/main/java/com/project/icey/global/exception/SuccessCode.java
@@ -41,6 +41,15 @@ public enum SuccessCode {
     GET_BEST_CANDIDATE(HttpStatus.OK, "과반수 이상이 가능한 시간들을 불러오는데 성공했습니다."),
     CONFIRMED_SCHEDULE(HttpStatus.OK, "약속이 확정되었습니다."),
 
+    //Team -> create은 위에 있음.
+    GET_TEAM_LIST_SUCCESS(HttpStatus.OK, "팀 목록 조회가 완료되었습니다."),
+    GET_INVITATION_SUCCESS(HttpStatus.OK, "초대 링크 조회가 완료되었습니다."),
+    JOIN_TEAM_SUCCESS(HttpStatus.CREATED, "팀 가입이 완료되었습니다."),
+    GET_TEAM_DETAIL_SUCCESS(HttpStatus.OK, "팀 상세 정보 조회가 완료되었습니다."),
+    DELETE_TEAM_SUCCESS(HttpStatus.NO_CONTENT, "팀이 성공적으로 삭제되었습니다."),
+    LEAVE_TEAM_SUCCESS(HttpStatus.NO_CONTENT, "팀 탈퇴가 완료되었습니다."),
+    GET_TEAM_INFO_BY_INVITATION_SUCCESS(HttpStatus.OK, "초대 링크를 통해 팀 정보를 불러왔습니다."),
+
     // Notice
     NOTICE_CREATED(HttpStatus.CREATED, "공지사항이 성공적으로 생성되었습니다."),
     NOTICE_UPDATED(HttpStatus.OK, "공지사항이 성공적으로 수정되었습니다."),

--- a/icey/src/main/resources/application.yml
+++ b/icey/src/main/resources/application.yml
@@ -54,3 +54,6 @@ spring:
 gemini:
   api:
     key: ${LLM_API_KEY}
+
+app:
+  base-url: ${APP_BASE_URL:http://localhost:8080/icey}


### PR DESCRIPTION
### 🔗 관련이슈

<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

closed #34

### ✏️구현내용 설명
아래 내용들을 위주로 코드를 수정하였습니다.

[ 초대장 조회 ] :초대한 사람의 닉네임(기능 명세서상 리더)이 뜨도록 수정


[ 팀 페이지 조회 ] : 현재 팀 인원수를 포함하여 반환


[ 팀 페이지 조회 ]: 화면에서 LEADER인지 MEMBER인 포함하여 반환


[ 팀 페이지 조회 ] : 팀 페이지와 연결된 약속잡기가 있는지 (진행중인지) boolean field


[ 팀 페이지 조회 ] : 팀 페이지와 연결된 약속잡기가 있을 경우 확정된 날짜 같이 넘겨 주기


[ 팀 페이지 조회 시 ] : 현재 날짜와 만료 날짜 같이 주기


[ 기능 추가 ] : 팀 페이지 만료 3일전에 SSE를 통한 알림 서비스 연결


예외처리 및 response 포맷 통일하기


### ✅ 테스트 방법
(필요하면, 스크린샷, 테스트 URL 등 첨부)


### 📢 공유해야 할 사항 또는 기타

- 약속잡기 한번밖에 못 생성하는데 그 후에 완료 버튼 누를 시 에러 보낼건데 그에 대한 안내 모달창이 있어야 할 거 같아 안내드려야할 것 같습니다.

- 리더가 만약 명함을 만들지 않았을 경우(= 팀 내 닉네임이 만들어지지 않았을 경우) 초대장에 어떻게 초대한사람 이름을 띄울지에 대한 방책 마련 필요이 필요합니다.  현재는 아예 에러를 내기 보다는 닉네임 미등록 사용자로 뜨도록 구현하였습니다.

- 초대링크는 이후 배포시에 도메인 붙이는 과정이 필요할 것 같다는 내용 전달하기..!