### PR TITLE
Fix: SecurityConfig에 GET /api/teams/invitation/** permitAll 추가 (초대장 조…

### DIFF
--- a/icey/src/main/java/com/project/icey/global/config/SecurityConfig.java
+++ b/icey/src/main/java/com/project/icey/global/config/SecurityConfig.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -88,6 +89,7 @@ public class SecurityConfig implements WebMvcConfigurer {
                                 "/api/verify/email", "/api/verify/resend", "/api/verify/reset-password", "/sse-test.html", "login.html", "/api/notification/subscribe",
                                 "/swagger-ui.html", "/v3/api-docs/**", "/swagger-ui/**","/login/**","/api/auth/kakao","/login/oauth2/**")
                         .permitAll() // 특정 요청 허용
+                        .requestMatchers(HttpMethod.GET, "/api/teams/invitation/**").permitAll()  //securityfilter에 추가하였습니다!
                         .requestMatchers("/api/rewards/update/**").hasAuthority("ADMIN") // API 권한 제한
                         .requestMatchers("/api/rewards/list/**").hasAnyAuthority("USER", "ADMIN")
                         .anyRequest().authenticated() // 나머지 요청은 인증 필요


### PR DESCRIPTION
…회 비로그인 허용)

### 🔗 관련이슈

<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

closed #52 

### ✏️구현내용 설명

초대장 조회는 비로그인 상태에서도 가능하도록 securityconfig 수정


### ✅ 테스트 방법
(필요하면, 스크린샷, 테스트 URL 등 첨부)


### 📢 공유해야 할 사항 또는 기타
