### PR TITLE
fix: 카드 템플릿이 사용된 팀 id 리스트 반환 api 추가

### DIFF
--- a/icey/src/main/java/com/project/icey/app/controller/CardController.java
+++ b/icey/src/main/java/com/project/icey/app/controller/CardController.java
@@ -48,6 +48,14 @@ public class CardController {
         cardService.delete(id, principal.getUser().getId());
     }
 
+    /* 템플릿별 사용중인 팀 id 리스트 조회 API */
+    @GetMapping("/{templateId}/used-teams")
+    public List<Long> getUsedTeamIds(@PathVariable Long templateId) {
+        return cardService.getTeamIdsUsingTemplate(templateId);
+    }
+
+
+
     // 2. 팀 명함 관련
 
     /* 팀 명함 목록 조회 (내 명함 식별 포함) */

--- a/icey/src/main/java/com/project/icey/app/service/CardService.java
+++ b/icey/src/main/java/com/project/icey/app/service/CardService.java
@@ -26,9 +26,10 @@ public class CardService {
     private final TeamRepository teamRepo;
 
     // 색상 팔레트
+    //7.22 번호별로 바꾸기(색깔이 아니라)
     private static final List<String> COLORS = List.of(
             "빨강", "파랑", "초록", "노랑", "주황",
-            "보라", "분홍", "회색", "민트", "하양"
+            "보라", "분홍", "회색", "검정", "하양"
     );
     private static final Random RANDOM = new Random();
 
@@ -77,6 +78,19 @@ public class CardService {
 
         cardRepo.delete(tpl);
     }
+
+    /* 이 템플릿이 사용된 팀 id 리스트 반환 */
+    public List<Long> getTeamIdsUsingTemplate(Long tplId) {
+        return cardRepo.findByOriginId(tplId)
+                .stream()
+                .filter(card -> card.getTeam() != null)
+                .map(card -> card.getTeam().getTeamId())
+                .distinct()
+                .toList();
+
+    }
+
+
 
     // [팀 명함 관련]
 


### PR DESCRIPTION
### 🔗 관련이슈

<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

closed #67 

### ✏️구현내용 설명

해당  템플릿이 사용된 팀 id 리스트를 반환

### ✅ 테스트 방법
(필요하면, 스크린샷, 테스트 URL 등 첨부)


### 📢 공유해야 할 사항 또는 기타

템플릿 카드들 중 들어온 팀페이지에서 사용중인 명함 표시는??
template.id === 내 팀카드.templateId → 사용중
아니면 → 교체 버튼 이런 식으로 가능할 것 같아서 일단은 수정 안 해둠...
