### PR TITLE
fix: 템플릿을 사용하는 팀 목록 조회 수정&내 팀카드 반환 api 추가

### DIFF
--- a/icey/src/main/java/com/project/icey/app/controller/CardController.java
+++ b/icey/src/main/java/com/project/icey/app/controller/CardController.java
@@ -3,6 +3,7 @@ package com.project.icey.app.controller;
 import com.project.icey.app.dto.CardRequest;
 import com.project.icey.app.dto.CardResponse;
 import com.project.icey.app.dto.CustomUserDetails;
+import com.project.icey.app.dto.SimpleTeamInfo;
 import com.project.icey.app.service.CardService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -48,11 +49,13 @@ public class CardController {
         cardService.delete(id, principal.getUser().getId());
     }
 
-    /* 템플릿별 사용중인 팀 id 리스트 조회 API */
+    /*이 템플릿을 사용하는 팀 목록 조회*/
     @GetMapping("/{templateId}/used-teams")
-    public List<Long> getUsedTeamIds(@PathVariable Long templateId) {
-        return cardService.getTeamIdsUsingTemplate(templateId);
+    public List<SimpleTeamInfo> getUsedTeamInfos(@PathVariable Long templateId) {
+        return cardService.getTeamInfosUsingTemplate(templateId);
     }
+
+
 
 
 
@@ -78,4 +81,14 @@ public class CardController {
                                      @AuthenticationPrincipal CustomUserDetails principal) {
         return cardService.applyTemplate(teamId, templateId, principal.getUser());
     }
+
+    // 내 팀카드(내가 이 팀에서 쓰는 카드)만 반환하는 API
+    @GetMapping("/teams/{teamId}/cards/my")
+    public CardResponse getMyTeamCard(
+            @PathVariable Long teamId,
+            @AuthenticationPrincipal CustomUserDetails principal
+    ) {
+        return cardService.getMyTeamCard(teamId, principal.getUser().getId());
+    }
+
 }

--- a/icey/src/main/java/com/project/icey/app/dto/SimpleTeamInfo.java
+++ b/icey/src/main/java/com/project/icey/app/dto/SimpleTeamInfo.java
@@ -1,0 +1,11 @@
+package com.project.icey.app.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class SimpleTeamInfo {
+    private Long id;
+    private String name;
+}

--- a/icey/src/main/java/com/project/icey/app/repository/TeamRepository.java
+++ b/icey/src/main/java/com/project/icey/app/repository/TeamRepository.java
@@ -20,4 +20,8 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
     @Query("SELECT t FROM Team t JOIN FETCH t.members m JOIN FETCH m.user WHERE t.teamId = :teamId")
     Optional<Team> findByIdWithMembersAndUsers(@Param("teamId") Long teamId);
 
+    // 여러 팀 id로 한 번에 여러 팀 찾아오기
+    List<Team> findByTeamIdIn(List<Long> teamIds);
+
+
 }


### PR DESCRIPTION
### 🔗 관련이슈

<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

closed #91 

### ✏️구현내용 설명

템플릿을 사용하는 팀 목록 조회 api: 기존에는 팀 id만 반환하고 있었는데 팀 닉네임을 반환하도록 수정했습니다(팀 레포 조회 및 디토 변환)
팀에서 사용하는 내 카드만 반환하는 api 따로 추가했습니다

팀에서 사용하는 내 카드만 반환하는 api 따로 추가

### ✅ 테스트 방법
(필요하면, 스크린샷, 테스트 URL 등 첨부)


### 📢 공유해야 할 사항 또는 기타
